### PR TITLE
Fixed incorrect function call of normalize_data_format with keras update

### DIFF
--- a/model.py
+++ b/model.py
@@ -62,7 +62,7 @@ class BilinearUpsampling(Layer):
 
         super(BilinearUpsampling, self).__init__(**kwargs)
 
-        self.data_format = conv_utils.normalize_data_format(data_format)
+        self.data_format = K.normalize_data_format(data_format)
         self.input_spec = InputSpec(ndim=4)
         if output_size:
             self.output_size = conv_utils.normalize_tuple(


### PR DESCRIPTION
With the keras update, normalize_data_format is no longer in conv_utils. Fixed this by importing normalize_data_format from keras.backend