### PR TITLE
Changes model's name to comply with TF's validation rules.

### DIFF
--- a/model.py
+++ b/model.py
@@ -503,7 +503,7 @@ def Deeplabv3(weights='pascal_voc', input_tensor=None, input_shape=(512, 512, 3)
     else:
         inputs = img_input
 
-    model = Model(inputs, x, name='deeplabv3+')
+    model = Model(inputs, x, name='deeplabv3plus')
 
     # load weights
 


### PR DESCRIPTION
When trying to run this model on multiple GPUs, using, one gets the following exception.

```
Traceback (most recent call last):
  File "/projects/deep-learning/deeplab-generic/experiments/train_sets.py", line 129, in <module>
    train_model = multi_gpu_model(train_model, gpus=4)
  File "/users/matt/venv/lib/python3.6/site-packages/tensorflow/python/keras/utils/multi_gpu_utils.py", line 239, in multi_gpu_model
    outputs = model(inputs)
  File "/users/matt/venv/lib/python3.6/site-packages/tensorflow/python/keras/engine/base_layer.py", line 702, in __call__
    with ops.name_scope(self._name_scope()):
  File "/users/matt/venv/lib/python3.6/site-packages/tensorflow/python/framework/ops.py", line 5775, in __enter__
    return self._name_scope.__enter__()
  File "/usr/local/miniconda/lib/python3.6/contextlib.py", line 81, in __enter__
    return next(self.gen)
  File "/users/matt/venv/lib/python3.6/site-packages/tensorflow/python/framework/ops.py", line 3846, in name_scope
    raise ValueError("'%s' is not a valid scope name" % name)
ValueError: 'deeplabv3+' is not a valid scope name
```

This is because TF enforces a certain format for model names (see [here](https://github.com/tensorflow/tensorflow/blob/r1.2/tensorflow/python/framework/ops.py#L2993)) through the following regular expressions:

```
[A-Za-z0-9.][A-Za-z0-9_.\\-/]*         (for scopes at the root)
[A-Za-z0-9_.\\-/]*                     (for other scopes)
```

Therefore the former model's name, `deeplabv3+`, didn't match these because of the `+` character and so the test failed.

This PR simply modifies this name to `deeplabv3plus` to fix this issue.