### PR TITLE
Cityscapes weights

### DIFF
--- a/model.py
+++ b/model.py
@@ -62,7 +62,7 @@ class BilinearUpsampling(Layer):
 
         super(BilinearUpsampling, self).__init__(**kwargs)
 
-        self.data_format = K.normalize_data_format(data_format)
+        self.data_format = K.image_data_format()
         self.input_spec = InputSpec(ndim=4)
         if output_size:
             self.output_size = conv_utils.normalize_tuple(

--- a/model.py
+++ b/model.py
@@ -49,7 +49,8 @@ from keras.utils.data_utils import get_file
 
 WEIGHTS_PATH_X = "https://github.com/bonlime/keras-deeplab-v3-plus/releases/download/1.1/deeplabv3_xception_tf_dim_ordering_tf_kernels.h5"
 WEIGHTS_PATH_MOBILE = "https://github.com/bonlime/keras-deeplab-v3-plus/releases/download/1.1/deeplabv3_mobilenetv2_tf_dim_ordering_tf_kernels.h5"
-
+WEIGHTS_PATH_X_CS = "https://github.com/rdiazgar/keras-deeplab-v3-plus/releases/download/1.2/deeplabv3_xception_tf_dim_ordering_tf_kernels_cityscapes.h5"
+WEIGHTS_PATH_MOBILE_CS = "https://github.com/rdiazgar/keras-deeplab-v3-plus/releases/download/1.2/deeplabv3_mobilenetv2_tf_dim_ordering_tf_kernels_cityscapes.h5"
 
 class BilinearUpsampling(Layer):
     """Just a simple bilinear upsampling layer. Works only with TF.
@@ -519,8 +520,14 @@ def Deeplabv3(weights='pascal_voc', input_tensor=None, input_shape=(512, 512, 3)
         model.load_weights(weights_path, by_name=True)
     elif weights == 'cityscapes':
         if backbone == 'xception':
-            weights_path = '/home/raul/.keras/models/deeplabv3_xception_tf_dim_ordering_tf_kernels_cityscapes.h5'
-            model.load_weights(weights_path, by_name=True)
+            weights_path = get_file('deeplabv3_xception_tf_dim_ordering_tf_kernels_cityscapes.h5',
+                                    WEIGHTS_PATH_X_CS,
+                                    cache_subdir='models')
+        else:
+            weights_path = get_file('deeplabv3_mobilenetv2_tf_dim_ordering_tf_kernels_cityscapes.h5',
+                                    WEIGHTS_PATH_MOBILE_CS,
+                                    cache_subdir='models')
+        model.load_weights(weights_path, by_name=True)
     return model
 
 

--- a/model.py
+++ b/model.py
@@ -311,7 +311,7 @@ def Deeplabv3(weights='pascal_voc', input_tensor=None, input_shape=(512, 512, 3)
 
     """
 
-    if not (weights in {'pascal_voc', None}):
+    if not (weights in {'pascal_voc', 'cityscapes', None}):
         raise ValueError('The `weights` argument should be either '
                          '`None` (random initialization) or `pascal_voc` '
                          '(pre-trained on PASCAL VOC)')
@@ -517,6 +517,10 @@ def Deeplabv3(weights='pascal_voc', input_tensor=None, input_shape=(512, 512, 3)
                                     WEIGHTS_PATH_MOBILE,
                                     cache_subdir='models')
         model.load_weights(weights_path, by_name=True)
+    elif weights == 'cityscapes':
+        if backbone == 'xception':
+            weights_path = '/home/raul/.keras/models/deeplabv3_xception_tf_dim_ordering_tf_kernels_cityscapes.h5'
+            model.load_weights(weights_path, by_name=True)
     return model
 
 

--- a/model.py
+++ b/model.py
@@ -314,7 +314,7 @@ def Deeplabv3(weights='pascal_voc', input_tensor=None, input_shape=(512, 512, 3)
 
     if not (weights in {'pascal_voc', 'cityscapes', None}):
         raise ValueError('The `weights` argument should be either '
-                         '`None` (random initialization) or `pascal_voc` '
+                         '`None` (random initialization), `pascal_voc`, or `cityscapes` '
                          '(pre-trained on PASCAL VOC)')
 
     if K.backend() != 'tensorflow':


### PR DESCRIPTION
Hi,

This is a pull request that provides a new set of pre-trained weights from the cityscapes dataset. I have been able to load both sets of weights (xception and mobilenetv2) and finetune the network with no problems.

The weights are stored under my forked repo with tag version 1.2. The model script file has the urls pointing at them and the weights are chosen simply by specifying weights='cityscapes'.

Sorry for the dirty set of commits in the PR. After updating from the upstream it looks a little bit messy, but we can properly merge them if the PR is accepted.

Best
Raul