### PR TITLE
TF beta1

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ CUDA==10.0
 Please see requirements.txt for the minimum requirements to run the example code in this README
 
 -------- 
-If you want to use older version, use following commands:
+If you want to use the older version of Tensorflow, use following commands:
 ```bash
 git clone https://github.com/bonlime/keras-deeplab-v3-plus/
 cd keras-deeplab-v3-plus/

--- a/README.md
+++ b/README.md
@@ -109,9 +109,15 @@ For MobileNetv2 there are pretrained weights only for `alpha=1`. However, you ca
 
 
 ### Requirement
-The latest vesrion  of this repo uses TF Keras, so you only need TF 2.0+ installed  
-tensorflow-gpu==2.0.0a0  
-CUDA==9.0   
+The latest version of this repo uses TF Keras, so you only need TF 2.0+ installed:  
+tensorflow==2.0.0-beta1
+
+or, with GPU/CUDA support:
+
+tensorflow-gpu==2.0.0-beta1
+CUDA==10.0   
+
+Please see requirements.txt for the minimum requirements to run the example code in this README
 
 -------- 
 If you want to use older version, use following commands:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ tensorflow==2.0.0-beta1
 or, with GPU/CUDA support:
 
 tensorflow-gpu==2.0.0-beta1
-CUDA==10.0   
+CUDA==10.1   
 
 Please see requirements.txt for the minimum requirements to run the example code in this README
 

--- a/extract_weights.py
+++ b/extract_weights.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import os
 import numpy as np
 import tensorflow as tf
-from keras.utils.data_utils import get_file
+from tensorflow.python.keras.utils.data_utils import get_file
 
 
 def get_xception_filename(key):
@@ -59,7 +59,7 @@ def extract_tensors_from_checkpoint_file(filename, output_folder='weights', net_
     if not os.path.exists(output_folder):
         os.makedirs(output_folder)
 
-    reader = tf.train.NewCheckpointReader(filename)
+    reader = tf.train.load_checkpoint(filename)
 
     for key in reader.get_variable_to_shape_map():
         # convert tensor name into the corresponding Keras layer weight name and save
@@ -72,6 +72,7 @@ def extract_tensors_from_checkpoint_file(filename, output_folder='weights', net_
             arr = reader.get_tensor(key)
             np.save(path, arr)
             print("tensor_name: ", key)
+
 
 CKPT_URL = 'http://download.tensorflow.org/models/deeplabv3_pascal_trainval_2018_01_04.tar.gz'
 CKPT_URL_MOBILE = 'http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_trainval_2018_01_29.tar.gz'

--- a/model.py
+++ b/model.py
@@ -479,6 +479,7 @@ def Deeplabv3(weights='pascal_voc', input_tensor=None, input_shape=(512, 512, 3)
         model.load_weights(weights_path, by_name=True)
     return model
 
+
 def preprocess_input(x):
     """Preprocesses a numpy array encoding a batch of images.
     # Arguments

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-keras==2.2.4
-tensorflow==2.0.0a0
+# Requirements to run the README
+
+tensorflow==2.0.0-beta1
 Pillow==6.0.0
 numpy
 matplotlib


### PR DESCRIPTION
I upgraded requirements to Tensorflow-2.0.0-beta1 and CUDA 10.0.  Everything seemed to work the same.  However, I did not test the CUDA piece.  Tensorflow claims to support CUDA 10.0.  Info here:

[https://www.tensorflow.org/beta](url)
[https://www.tensorflow.org/install/gpu](url)