### PR TITLE
Typecast error fix

### DIFF
--- a/model.py
+++ b/model.py
@@ -174,7 +174,7 @@ def _make_divisible(v, divisor, min_value=None):
 
 
 def _inverted_res_block(inputs, expansion, stride, alpha, filters, block_id, skip_connection, rate=1):
-    in_channels = inputs.shape[-1]  # inputs._keras_shape[-1]
+    in_channels = inputs.shape[-1].value  # inputs._keras_shape[-1]
     pointwise_conv_filters = int(filters * alpha)
     pointwise_filters = _make_divisible(pointwise_conv_filters, 8)
     x = inputs
@@ -182,7 +182,7 @@ def _inverted_res_block(inputs, expansion, stride, alpha, filters, block_id, ski
     if block_id:
         # Expand
 
-        x = Conv2D(int(expansion * in_channels), kernel_size=1, padding='same',
+        x = Conv2D(expansion * in_channels, kernel_size=1, padding='same',
                    use_bias=False, activation=None,
                    name=prefix + 'expand')(x)
         x = BatchNormalization(epsilon=1e-3, momentum=0.999,

--- a/model.py
+++ b/model.py
@@ -182,7 +182,7 @@ def _inverted_res_block(inputs, expansion, stride, alpha, filters, block_id, ski
     if block_id:
         # Expand
 
-        x = Conv2D(expansion * in_channels, kernel_size=1, padding='same',
+        x = Conv2D(int(expansion * in_channels), kernel_size=1, padding='same',
                    use_bias=False, activation=None,
                    name=prefix + 'expand')(x)
         x = BatchNormalization(epsilon=1e-3, momentum=0.999,


### PR DESCRIPTION
Tensorflow version: "1.14.0"
Error message: "TypeError: Failed to convert object of type <class 'tuple'> to Tensor. Contents: (1, 1, 16, Dimension(96)). Consider casting elements to a supported type."