### PR TITLE
Fix pretrained mobilenet for single-channel images

### DIFF
--- a/model.py
+++ b/model.py
@@ -306,8 +306,8 @@ def Deeplabv3(weights='pascal_voc', input_tensor=None, input_shape=(512, 512, 3)
         first_block_filters = _make_divisible(32 * alpha, 8)
         x = Conv2D(first_block_filters,
                    kernel_size=3,
-                   strides=(2, 2), padding='same',
-                   use_bias=False, name='Conv')(img_input)
+                   strides=(2, 2), padding='same', use_bias=False,
+                   name='Conv' if input_shape[2] == 3 else 'Conv_')(img_input)
         x = BatchNormalization(
             epsilon=1e-3, momentum=0.999, name='Conv_BN')(x)
         x = Activation(tf.nn.relu6, name='Conv_Relu6')(x)


### PR DESCRIPTION
The first convolution (named `'Conv'`) has weights of the shape (3, 3, 3, 32) in the pretrained weights. If the model is created with input_shape(x, y, 1), the weights need to be (3, 3, 1, 32), which causes an exception. Renaming the first convolution for input_shapes that don't have three channels solves this.